### PR TITLE
Finish Renaming R_RISCV_QC_LO20_U to _ABS20_U

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `QUALCOMM` relocation 192 has been renamed to `R_RISCV_QC_ABS20_U` to reflect
+  that this is not part of a HI/LO pair (there is no upper bits counterpart).
+  Instead, this makes it clear that this is for materialising absolute addresses
+  that are 20 bits. The relocation ID, type, field, and calculation have not
+  changed, only the human-readable name.
+
 ## [v0.1]
 
 - Initial Version of Qualcomm Extensions

--- a/src/relaxations.adoc
+++ b/src/relaxations.adoc
@@ -422,7 +422,7 @@ NOTE: This relaxation could have used `ADDI` as the destination instruction (whi
 
 ==== Extended to Compressed Address Relaxation
 
-  Target Relocation:: R_RISCV_QC_E_32, R_RISCV_QC_LO20_U
+  Target Relocation:: R_RISCV_QC_E_32, R_RISCV_QC_ABS20_U
 
   Description:: This relaxation type can relax a `qc.e.li` or `qc.li` instruction for loading the address of a symbol reference into a `c.li`.
 
@@ -430,7 +430,7 @@ NOTE: This relaxation could have used `ADDI` as the destination instruction (whi
 
   Extensions Required:: `Zca`
 
-  Relaxation:: Instruction associated with `R_RISCV_QC_E_32` or `R_RISCV_QC_LO20_U` can be replaced with a `C.LI` instruction.
+  Relaxation:: Instruction associated with `R_RISCV_QC_E_32` or `R_RISCV_QC_ABS20_U` can be replaced with a `C.LI` instruction.
 
   Example::
 +
@@ -459,7 +459,7 @@ Relaxation candidate:
 [,asm]
 ----
     qc.li t1, 0    # R_RISCV_VENDOR QUALCOMM
-                   # R_RISCV_QC_LO20_U symbol
+                   # R_RISCV_QC_ABS20_U symbol
                    # R_RISCV_RELAX
     # 4 bytes
 ----


### PR DESCRIPTION
I missed some references in the relaxation document, and a changelog item for this change.